### PR TITLE
[FEATURE] Make extension TYPO3 v11 compatible

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,10 +1,12 @@
 {
     "name": "namelesscoder/typo3-cms-newrelic-integration",
     "type": "typo3-cms-extension",
+    "description": "A collection of integrations for Newrelic monitoring",
     "require": {
-        "typo3/cms-core": "^8|^9|^10",
-        "typo3/cms-frontend": "^8|^9|^10",
-        "typo3/cms-backend": "^8|^9|^10"
+        "php": ">=7.0 <8.2",
+        "typo3/cms-core": "^8 || ^9 || ^10 || ^11",
+        "typo3/cms-frontend": "^8 || ^9 || ^10 || ^11",
+        "typo3/cms-backend": "^8 || ^9 || ^10 || ^11"
     },
     "autoload": {
         "psr-4": {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -23,8 +23,8 @@ $EM_CONF['newrelic_integration'] = array (
   array (
     'depends' =>
     array (
-      'php' => '7.0.0-7.4.99',
-      'typo3' => '8.7.0-10.4.99',
+      'php' => '7.0.0-8.1.99',
+      'typo3' => '8.7.0-11.5.99',
     ),
     'conflicts' =>
     array (

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -1,6 +1,6 @@
 <?php
 if (!defined('TYPO3_MODE')) {
-	die('Access denied.');
+    die('Access denied.');
 }
 
 (function() {
@@ -59,10 +59,12 @@ if (!defined('TYPO3_MODE')) {
             newrelic_add_custom_tracer(\TYPO3\CMS\Core\Cache\Backend\FileBackend::class . '::get');
             newrelic_add_custom_tracer(\TYPO3\CMS\Core\Cache\Backend\FileBackend::class . '::set');
             newrelic_add_custom_tracer(\TYPO3\CMS\Core\Cache\Backend\FileBackend::class . '::flush');
-            newrelic_add_custom_tracer(\TYPO3\CMS\Core\Cache\Backend\ApcBackend::class . '::get');
-            newrelic_add_custom_tracer(\TYPO3\CMS\Core\Cache\Backend\ApcBackend::class . '::set');
-            newrelic_add_custom_tracer(\TYPO3\CMS\Core\Cache\Backend\ApcBackend::class . '::flush');
-            newrelic_add_custom_tracer(\TYPO3\CMS\Core\Cache\Backend\ApcBackend::class . '::flushByTags');
+            if (class_exists(\TYPO3\CMS\Core\Cache\Backend\ApcBackend::class)) {
+                newrelic_add_custom_tracer(\TYPO3\CMS\Core\Cache\Backend\ApcBackend::class . '::get');
+                newrelic_add_custom_tracer(\TYPO3\CMS\Core\Cache\Backend\ApcBackend::class . '::set');
+                newrelic_add_custom_tracer(\TYPO3\CMS\Core\Cache\Backend\ApcBackend::class . '::flush');
+                newrelic_add_custom_tracer(\TYPO3\CMS\Core\Cache\Backend\ApcBackend::class . '::flushByTags');
+            }
             newrelic_add_custom_tracer(\TYPO3\CMS\Core\Cache\Backend\ApcuBackend::class . '::get');
             newrelic_add_custom_tracer(\TYPO3\CMS\Core\Cache\Backend\ApcuBackend::class . '::set');
             newrelic_add_custom_tracer(\TYPO3\CMS\Core\Cache\Backend\ApcuBackend::class . '::flush');
@@ -97,11 +99,12 @@ if (!defined('TYPO3_MODE')) {
                 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['processCmdmapClass'][] = \NamelessCoder\NewrelicIntegration\Hooks\DataHandlerHookSubscriber::class;
             }
 
-            $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['cms/layout/db_layout.php']['drawFooterHook']['newrelic_integration'] = function(
-                array $parameters,
-                \TYPO3\CMS\Backend\Controller\PageLayoutController $pageLayoutController
-            ) {
-                newrelic_name_transaction('BE/' . $pageLayoutController->MCONF['name']);
+            /*
+             * Since there is no constant for the 'web_layout' module name, use it directly.
+             * Up to TYPO3 v10, it was possible to use $pageLayoutController->MCONF['name']
+             */
+            $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['cms/layout/db_layout.php']['drawFooterHook']['newrelic_integration'] = function() {
+                newrelic_name_transaction('BE/web_layout');
             };
 
         }


### PR DESCRIPTION
With this pull request, support for TYPO3 v11 will be added.

With minimum adjustments, the extension has been made compatible.

The `ApcBackend` has been removed in TYPO3 v11, so to prevent errors, a `class_exists` check has been added.

For the `drawFooterHook`, an adjustment has been made to make sure the `BE/web_layout` transaction name will be set. This didn't work in v10 either, because the `$pageLayoutController->MCONF` had been removed.

In the composer.json file, the php constraint has been set to work on php 7.0 and up, and php 8.0 and 8.1.