### PR TITLE
Add TYPO3 v12 support 

### DIFF
--- a/Classes/Event/AfterPageResolveEvent.php
+++ b/Classes/Event/AfterPageResolveEvent.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NamelessCoder\NewrelicIntegration\Event;
+
+use TYPO3\CMS\Core\Configuration\Exception\ExtensionConfigurationExtensionNotConfiguredException;
+use TYPO3\CMS\Core\Configuration\Exception\ExtensionConfigurationPathDoesNotExistException;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+use TYPO3\CMS\Core\Http\ApplicationType;
+use TYPO3\CMS\Frontend\Event\AfterPageAndLanguageIsResolvedEvent;
+
+class AfterPageResolveEvent
+{
+    /** @var ExtensionConfiguration */
+    protected $configuration;
+
+    public function __construct(ExtensionConfiguration $configuration)
+    {
+        $this->configuration = $configuration;
+    }
+
+    public function setNewrelicNameTransaction(AfterPageAndLanguageIsResolvedEvent $event)
+    {
+        if (!extension_loaded('newrelic')) {
+            return;
+        }
+
+        $applicationType = ApplicationType::fromRequest($event->getRequest())->abbreviate();
+
+        if ($this->isTracePageUidEnabled()) {
+            newrelic_name_transaction($applicationType . '/page-' . $event->getController()->id . '-default');
+
+            if ($this->isTracePageTypeEnabled()) {
+                $type = $event->getRequest()->getParsedBody()['type']
+                    ?? $event->getRequest()->getQueryParams()['type']
+                    ?? null;
+
+                if ($type !== null) {
+                    newrelic_name_transaction($applicationType . '/page-' . $event->getController()->id . '-type' . $type);
+                }
+            }
+        }
+    }
+
+    protected function isTracePageUidEnabled(): bool
+    {
+        try {
+            return (bool)$this->configuration->get('newrelic_integration', 'tracePageUid');
+        } catch (ExtensionConfigurationExtensionNotConfiguredException $e) {
+            return true;
+        } catch (ExtensionConfigurationPathDoesNotExistException $e) {
+            return true;
+        }
+    }
+
+    protected function isTracePageTypeEnabled(): bool
+    {
+        try {
+            return (bool)$this->configuration->get('newrelic_integration', 'tracePageType');
+        } catch (ExtensionConfigurationExtensionNotConfiguredException $e) {
+            return true;
+        } catch (ExtensionConfigurationPathDoesNotExistException $e) {
+            return true;
+        }
+    }
+}

--- a/Classes/Event/PageLayoutContentEvent.php
+++ b/Classes/Event/PageLayoutContentEvent.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NamelessCoder\NewrelicIntegration\Event;
+
+use TYPO3\CMS\Backend\Controller\Event\ModifyPageLayoutContentEvent;
+use TYPO3\CMS\Core\Http\ApplicationType;
+
+class PageLayoutContentEvent
+{
+    public function setNewrelicNameTransaction(ModifyPageLayoutContentEvent $event)
+    {
+        if (!extension_loaded('newrelic')) {
+            return;
+        }
+
+        newrelic_name_transaction('BE/web_layout');
+    }
+}

--- a/Classes/Middleware/FrontendUserAuthenticator.php
+++ b/Classes/Middleware/FrontendUserAuthenticator.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NamelessCoder\NewrelicIntegration\Middleware;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
+
+class FrontendUserAuthenticator implements MiddlewareInterface
+{
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        if (!extension_loaded('newrelic')) {
+            return $handler->handle($request);
+        }
+
+        if ($GLOBALS['TSFE'] instanceof TypoScriptFrontendController) {
+            $this->processFrontendLogin($request);
+        }
+
+        return $handler->handle($request);
+    }
+
+    protected function processFrontendLogin(ServerRequestInterface $request)
+    {
+        $login = $GLOBALS['TSFE']->fe_user->getLoginFormData($request);
+        if (isset($login['status']) && $login['status'] === 'login') {
+            newrelic_name_transaction('FE login');
+        }
+
+        if (!isset($GLOBALS['TSFE']->fe_user->user['uid']) || $GLOBALS['TSFE']->fe_user->user['uid'] === null) {
+            newrelic_add_custom_parameter('Frontend user', 'Anonymous');
+        } else {
+            $traceFrontendUsersFields = !empty($configuration['traceFrontendUsersFields'])
+                ? GeneralUtility::trimExplode(',', $configuration['traceFrontendUsersFields'])
+                : ['uid', 'username', 'company', 'email'];
+            $traceFields = [];
+
+            foreach ($traceFrontendUsersFields as $traceFrontendUsersField) {
+                $traceFields[] = $GLOBALS['TSFE']->fe_user->user[$traceFrontendUsersField];
+            }
+
+            newrelic_add_custom_parameter('Frontend user', implode(', ', $traceFields));
+        }
+    }
+}

--- a/Configuration/RequestMiddlewares.php
+++ b/Configuration/RequestMiddlewares.php
@@ -3,9 +3,15 @@
 return [
     'frontend' => [
          'namelessCoder/newrelicIntegration/new-relic' => [
-            'target' => NamelessCoder\NewrelicIntegration\Middleware\NewRelicInstrumentation::class,
+            'target' => \NamelessCoder\NewrelicIntegration\Middleware\NewRelicInstrumentation::class,
             'after' => [
                 'typo3/cms-frontend/content-length-headers',
+            ],
+        ],
+        'namelessCoder/newrelicIntegration/frontend-user-authenticator' => [
+            'target' => \NamelessCoder\NewrelicIntegration\Middleware\FrontendUserAuthenticator::class,
+            'after' => [
+                'typo3/cms-frontend/authentication',
             ],
         ],
     ]

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -1,0 +1,24 @@
+services:
+  _defaults:
+    autowire: true
+    autoconfigure: true
+    public: false
+
+  NamelessCoder\NewrelicIntegration\:
+    resource: '../Classes/*'
+
+  NamelessCoder\NewrelicIntegration\Event\AfterPageResolveEvent:
+    public: true
+    tags:
+      - name: event.listener
+        identifier: 'namelessCoder/newrelicIntegration/after-page-resolve-event'
+        method: 'setNewrelicNameTransaction'
+        event: TYPO3\CMS\Frontend\Event\AfterPageAndLanguageIsResolvedEvent
+
+  NamelessCoder\NewrelicIntegration\Event\PageLayoutContentEvent:
+    public: true
+    tags:
+      - name: event.listener
+        identifier: 'namelessCoder/newrelicIntegration/page-layout-content-event'
+        method: 'setNewrelicNameTransaction'
+        event: TYPO3\CMS\Backend\Controller\Event\ModifyPageLayoutContentEvent

--- a/composer.json
+++ b/composer.json
@@ -4,9 +4,9 @@
     "description": "A collection of integrations for Newrelic monitoring",
     "require": {
         "php": ">=7.0 <8.3",
-        "typo3/cms-core": "^8 || ^9 || ^10 || ^11",
-        "typo3/cms-frontend": "^8 || ^9 || ^10 || ^11",
-        "typo3/cms-backend": "^8 || ^9 || ^10 || ^11"
+        "typo3/cms-core": "^8 || ^9 || ^10 || ^11 || ^12",
+        "typo3/cms-frontend": "^8 || ^9 || ^10 || ^11 || ^12",
+        "typo3/cms-backend": "^8 || ^9 || ^10 || ^11 || ^12"
     },
     "autoload": {
         "psr-4": {

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -10,7 +10,7 @@ defined('TYPO3_MODE') || defined('TYPO3') or die();
     $applicationType = 'BE';
     if (defined('TYPO3_MODE')) {
         $applicationType = TYPO3_MODE;
-    } elseif ($GLOBALS['TYPO3_REQUEST'] !== null) {
+    } elseif (($GLOBALS['TYPO3_REQUEST'] ?? null) instanceof \Psr\Http\Message\ServerRequestInterface) {
         $applicationType = \TYPO3\CMS\Core\Http\ApplicationType::fromRequest($GLOBALS['TYPO3_REQUEST'])->abbreviate();
     }
 
@@ -156,7 +156,7 @@ defined('TYPO3_MODE') || defined('TYPO3') or die();
                 array $parameters,
                 \TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController $controller
             ) use ($configuration) {
-                $login = $controller->fe_user->getLoginFormData($GLOBALS['TYPO3_REQUEST']);
+                $login = $controller->fe_user->getLoginFormData();
                 if (!empty($login) && $login['status'] === 'login') {
                     newrelic_name_transaction('FE login');
                 }

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -1,165 +1,183 @@
 <?php
-if (!defined('TYPO3_MODE')) {
-    die('Access denied.');
-}
 
-(function() {
-    if (extension_loaded('newrelic')) {
-        if (!empty($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['newrelic_integration']) && version_compare(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::getExtensionVersion('core'), '9.5', '>')) {
-            // Import settings that exist in serialized arrays. These override settings that would otherwise be stored in the new
-            // raw array. Once settings have been saved by install tool "Settings" module, the old serialized value is removed from
-            // the array and this condition will no longer trigger.
-            $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['newrelic_integration'] = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['newrelic_integration']);
-        }
-        $configuration = $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['newrelic_integration'] ?? [];
+defined('TYPO3_MODE') || defined('TYPO3') or die();
 
+(static function() {
+    if (!extension_loaded('newrelic')) {
+        return;
+    }
 
-        if (!empty($GLOBALS['argv'])) {
-            newrelic_name_transaction('CLI/command/' . $GLOBALS['argv'][1] . (isset($GLOBALS['argv'][2]) ? '/' . $GLOBALS['argv'][2] : ''));
-        } else {
-            newrelic_name_transaction(TYPO3_MODE);
-        }
+    $applicationType = 'BE';
+    if (defined('TYPO3_MODE')) {
+        $applicationType = TYPO3_MODE;
+    } elseif ($GLOBALS['TYPO3_REQUEST'] !== null) {
+        $applicationType = \TYPO3\CMS\Core\Http\ApplicationType::fromRequest($GLOBALS['TYPO3_REQUEST'])->abbreviate();
+    }
 
-        newrelic_capture_params(true);
+    if (!empty($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['newrelic_integration']) && version_compare(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::getExtensionVersion('core'), '9.5', '>')) {
+        // Import settings that exist in serialized arrays. These override settings that would otherwise be stored in the new
+        // raw array. Once settings have been saved by install tool "Settings" module, the old serialized value is removed from
+        // the array and this condition will no longer trigger.
+        $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['newrelic_integration'] = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['newrelic_integration']);
+    }
+    $configuration = $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['newrelic_integration'] ?? [];
 
-        if (isset($configuration['traceObjectInstancing']) && $configuration['traceObjectInstancing']) {
-            newrelic_add_custom_tracer(\TYPO3\CMS\Core\Utility\GeneralUtility::class . '::makeInstance');
+    if (!empty($GLOBALS['argv'])) {
+        newrelic_name_transaction('CLI/command/' . $GLOBALS['argv'][1] . (isset($GLOBALS['argv'][2]) ? '/' . $GLOBALS['argv'][2] : ''));
+    } else {
+        newrelic_name_transaction($applicationType);
+    }
+
+    newrelic_capture_params(true);
+
+    if (isset($configuration['traceObjectInstancing']) && $configuration['traceObjectInstancing']) {
+        newrelic_add_custom_tracer(\TYPO3\CMS\Core\Utility\GeneralUtility::class . '::makeInstance');
+        if (class_exists(\TYPO3\CMS\Extbase\Object\ObjectManager::class)) {
             newrelic_add_custom_tracer(\TYPO3\CMS\Extbase\Object\ObjectManager::class . '::get');
         }
+    }
 
-        if (isset($configuration['traceFluidParsing']) && $configuration['traceFluidParsing']) {
-            newrelic_add_custom_tracer(\TYPO3Fluid\Fluid\Core\Parser\TemplateParser::class . '::parse');
+    if (isset($configuration['traceFluidParsing']) && $configuration['traceFluidParsing']) {
+        newrelic_add_custom_tracer(\TYPO3Fluid\Fluid\Core\Parser\TemplateParser::class . '::parse');
+    }
+
+    if (isset($configuration['traceFluidRendering']) && $configuration['traceFluidRendering']) {
+        newrelic_add_custom_tracer(\TYPO3Fluid\Fluid\View\TemplateView::class . '::render');
+        newrelic_add_custom_tracer(\TYPO3Fluid\Fluid\View\TemplateView::class . '::renderPartial');
+        newrelic_add_custom_tracer(\TYPO3Fluid\Fluid\View\TemplateView::class . '::renderSection');
+    }
+
+    if (isset($configuration['traceExtbaseControllers']) && $configuration['traceExtbaseControllers']) {
+        newrelic_add_custom_tracer(\TYPO3\CMS\Extbase\Mvc\Controller\ActionController::class . '::processRequest');
+        newrelic_add_custom_tracer(\TYPO3\CMS\Extbase\Mvc\Controller\ActionController::class . '::initializeAction');
+        newrelic_add_custom_tracer(\TYPO3\CMS\Extbase\Mvc\Controller\ActionController::class . '::callActionMethod');
+    }
+
+    if (isset($configuration['traceExtbasePersistence']) && $configuration['traceExtbasePersistence']) {
+        newrelic_add_custom_tracer(\TYPO3\CMS\Extbase\Persistence\Generic\Query::class . '::execute');
+        newrelic_add_custom_tracer(\TYPO3\CMS\Extbase\Property\PropertyMapper::class . '::convert');
+    }
+
+    if (isset($configuration['traceCacheOperations']) && $configuration['traceCacheOperations']) {
+        newrelic_add_custom_tracer(\TYPO3\CMS\Core\Cache\Backend\Typo3DatabaseBackend::class . '::get');
+        newrelic_add_custom_tracer(\TYPO3\CMS\Core\Cache\Backend\Typo3DatabaseBackend::class . '::set');
+        newrelic_add_custom_tracer(\TYPO3\CMS\Core\Cache\Backend\Typo3DatabaseBackend::class . '::flush');
+        newrelic_add_custom_tracer(\TYPO3\CMS\Core\Cache\Backend\Typo3DatabaseBackend::class . '::flushByTags');
+        newrelic_add_custom_tracer(\TYPO3\CMS\Core\Cache\Backend\SimpleFileBackend::class . '::get');
+        newrelic_add_custom_tracer(\TYPO3\CMS\Core\Cache\Backend\SimpleFileBackend::class . '::set');
+        newrelic_add_custom_tracer(\TYPO3\CMS\Core\Cache\Backend\SimpleFileBackend::class . '::flush');
+        newrelic_add_custom_tracer(\TYPO3\CMS\Core\Cache\Backend\FileBackend::class . '::get');
+        newrelic_add_custom_tracer(\TYPO3\CMS\Core\Cache\Backend\FileBackend::class . '::set');
+        newrelic_add_custom_tracer(\TYPO3\CMS\Core\Cache\Backend\FileBackend::class . '::flush');
+        if (class_exists(\TYPO3\CMS\Core\Cache\Backend\ApcBackend::class)) {
+            newrelic_add_custom_tracer(\TYPO3\CMS\Core\Cache\Backend\ApcBackend::class . '::get');
+            newrelic_add_custom_tracer(\TYPO3\CMS\Core\Cache\Backend\ApcBackend::class . '::set');
+            newrelic_add_custom_tracer(\TYPO3\CMS\Core\Cache\Backend\ApcBackend::class . '::flush');
+            newrelic_add_custom_tracer(\TYPO3\CMS\Core\Cache\Backend\ApcBackend::class . '::flushByTags');
         }
-
-        if (isset($configuration['traceFluidRendering']) && $configuration['traceFluidRendering']) {
-            newrelic_add_custom_tracer(\TYPO3Fluid\Fluid\View\TemplateView::class . '::render');
-            newrelic_add_custom_tracer(\TYPO3Fluid\Fluid\View\TemplateView::class . '::renderPartial');
-            newrelic_add_custom_tracer(\TYPO3Fluid\Fluid\View\TemplateView::class . '::renderSection');
-        }
-
-        if (isset($configuration['traceExtbaseControllers']) && $configuration['traceExtbaseControllers']) {
-            newrelic_add_custom_tracer(\TYPO3\CMS\Extbase\Mvc\Controller\ActionController::class . '::processRequest');
-            newrelic_add_custom_tracer(\TYPO3\CMS\Extbase\Mvc\Controller\ActionController::class . '::initializeAction');
-            newrelic_add_custom_tracer(\TYPO3\CMS\Extbase\Mvc\Controller\ActionController::class . '::callActionMethod');
-        }
-
-        if (isset($configuration['traceExtbasePersistence']) && $configuration['traceExtbasePersistence']) {
-            newrelic_add_custom_tracer(\TYPO3\CMS\Extbase\Persistence\Generic\Query::class . '::execute');
-            newrelic_add_custom_tracer(\TYPO3\CMS\Extbase\Property\PropertyMapper::class . '::convert');
-        }
-
-        if (isset($configuration['traceCacheOperations']) && $configuration['traceCacheOperations']) {
-            newrelic_add_custom_tracer(\TYPO3\CMS\Core\Cache\Backend\Typo3DatabaseBackend::class . '::get');
-            newrelic_add_custom_tracer(\TYPO3\CMS\Core\Cache\Backend\Typo3DatabaseBackend::class . '::set');
-            newrelic_add_custom_tracer(\TYPO3\CMS\Core\Cache\Backend\Typo3DatabaseBackend::class . '::flush');
-            newrelic_add_custom_tracer(\TYPO3\CMS\Core\Cache\Backend\Typo3DatabaseBackend::class . '::flushByTags');
-            newrelic_add_custom_tracer(\TYPO3\CMS\Core\Cache\Backend\SimpleFileBackend::class . '::get');
-            newrelic_add_custom_tracer(\TYPO3\CMS\Core\Cache\Backend\SimpleFileBackend::class . '::set');
-            newrelic_add_custom_tracer(\TYPO3\CMS\Core\Cache\Backend\SimpleFileBackend::class . '::flush');
-            newrelic_add_custom_tracer(\TYPO3\CMS\Core\Cache\Backend\FileBackend::class . '::get');
-            newrelic_add_custom_tracer(\TYPO3\CMS\Core\Cache\Backend\FileBackend::class . '::set');
-            newrelic_add_custom_tracer(\TYPO3\CMS\Core\Cache\Backend\FileBackend::class . '::flush');
-            if (class_exists(\TYPO3\CMS\Core\Cache\Backend\ApcBackend::class)) {
-                newrelic_add_custom_tracer(\TYPO3\CMS\Core\Cache\Backend\ApcBackend::class . '::get');
-                newrelic_add_custom_tracer(\TYPO3\CMS\Core\Cache\Backend\ApcBackend::class . '::set');
-                newrelic_add_custom_tracer(\TYPO3\CMS\Core\Cache\Backend\ApcBackend::class . '::flush');
-                newrelic_add_custom_tracer(\TYPO3\CMS\Core\Cache\Backend\ApcBackend::class . '::flushByTags');
-            }
-            newrelic_add_custom_tracer(\TYPO3\CMS\Core\Cache\Backend\ApcuBackend::class . '::get');
-            newrelic_add_custom_tracer(\TYPO3\CMS\Core\Cache\Backend\ApcuBackend::class . '::set');
-            newrelic_add_custom_tracer(\TYPO3\CMS\Core\Cache\Backend\ApcuBackend::class . '::flush');
-            newrelic_add_custom_tracer(\TYPO3\CMS\Core\Cache\Backend\ApcuBackend::class . '::flushByTags');
-            newrelic_add_custom_tracer(\TYPO3\CMS\Core\Cache\Backend\MemcachedBackend::class . '::get');
-            newrelic_add_custom_tracer(\TYPO3\CMS\Core\Cache\Backend\MemcachedBackend::class . '::set');
-            newrelic_add_custom_tracer(\TYPO3\CMS\Core\Cache\Backend\MemcachedBackend::class . '::flush');
-            newrelic_add_custom_tracer(\TYPO3\CMS\Core\Cache\Backend\MemcachedBackend::class . '::flushByTags');
-            newrelic_add_custom_tracer(\TYPO3\CMS\Core\Cache\Backend\NullBackend::class . '::get');
-            newrelic_add_custom_tracer(\TYPO3\CMS\Core\Cache\Backend\NullBackend::class . '::set');
-            newrelic_add_custom_tracer(\TYPO3\CMS\Core\Cache\Backend\TransientMemoryBackend::class . '::get');
-            newrelic_add_custom_tracer(\TYPO3\CMS\Core\Cache\Backend\TransientMemoryBackend::class . '::set');
-            newrelic_add_custom_tracer(\TYPO3\CMS\Core\Cache\Backend\TransientMemoryBackend::class . '::flush');
-            newrelic_add_custom_tracer(\TYPO3\CMS\Core\Cache\Backend\TransientMemoryBackend::class . '::flushByTags');
-            newrelic_add_custom_tracer(\TYPO3\CMS\Core\Cache\Backend\RedisBackend::class . '::get');
-            newrelic_add_custom_tracer(\TYPO3\CMS\Core\Cache\Backend\RedisBackend::class . '::set');
-            newrelic_add_custom_tracer(\TYPO3\CMS\Core\Cache\Backend\RedisBackend::class . '::flush');
-            newrelic_add_custom_tracer(\TYPO3\CMS\Core\Cache\Backend\RedisBackend::class . '::flushByTags');
+        newrelic_add_custom_tracer(\TYPO3\CMS\Core\Cache\Backend\ApcuBackend::class . '::get');
+        newrelic_add_custom_tracer(\TYPO3\CMS\Core\Cache\Backend\ApcuBackend::class . '::set');
+        newrelic_add_custom_tracer(\TYPO3\CMS\Core\Cache\Backend\ApcuBackend::class . '::flush');
+        newrelic_add_custom_tracer(\TYPO3\CMS\Core\Cache\Backend\ApcuBackend::class . '::flushByTags');
+        newrelic_add_custom_tracer(\TYPO3\CMS\Core\Cache\Backend\MemcachedBackend::class . '::get');
+        newrelic_add_custom_tracer(\TYPO3\CMS\Core\Cache\Backend\MemcachedBackend::class . '::set');
+        newrelic_add_custom_tracer(\TYPO3\CMS\Core\Cache\Backend\MemcachedBackend::class . '::flush');
+        newrelic_add_custom_tracer(\TYPO3\CMS\Core\Cache\Backend\MemcachedBackend::class . '::flushByTags');
+        newrelic_add_custom_tracer(\TYPO3\CMS\Core\Cache\Backend\NullBackend::class . '::get');
+        newrelic_add_custom_tracer(\TYPO3\CMS\Core\Cache\Backend\NullBackend::class . '::set');
+        newrelic_add_custom_tracer(\TYPO3\CMS\Core\Cache\Backend\TransientMemoryBackend::class . '::get');
+        newrelic_add_custom_tracer(\TYPO3\CMS\Core\Cache\Backend\TransientMemoryBackend::class . '::set');
+        newrelic_add_custom_tracer(\TYPO3\CMS\Core\Cache\Backend\TransientMemoryBackend::class . '::flush');
+        newrelic_add_custom_tracer(\TYPO3\CMS\Core\Cache\Backend\TransientMemoryBackend::class . '::flushByTags');
+        newrelic_add_custom_tracer(\TYPO3\CMS\Core\Cache\Backend\RedisBackend::class . '::get');
+        newrelic_add_custom_tracer(\TYPO3\CMS\Core\Cache\Backend\RedisBackend::class . '::set');
+        newrelic_add_custom_tracer(\TYPO3\CMS\Core\Cache\Backend\RedisBackend::class . '::flush');
+        newrelic_add_custom_tracer(\TYPO3\CMS\Core\Cache\Backend\RedisBackend::class . '::flushByTags');
+        if (class_exists(\TYPO3\CMS\Core\Cache\Backend\PdoBackend::class)) {
             newrelic_add_custom_tracer(\TYPO3\CMS\Core\Cache\Backend\PdoBackend::class . '::get');
             newrelic_add_custom_tracer(\TYPO3\CMS\Core\Cache\Backend\PdoBackend::class . '::set');
             newrelic_add_custom_tracer(\TYPO3\CMS\Core\Cache\Backend\PdoBackend::class . '::flush');
             newrelic_add_custom_tracer(\TYPO3\CMS\Core\Cache\Backend\PdoBackend::class . '::flushByTags');
+        }
+        if (class_exists(\TYPO3\CMS\Core\Cache\Backend\WincacheBackend::class)) {
             newrelic_add_custom_tracer(\TYPO3\CMS\Core\Cache\Backend\WincacheBackend::class . '::get');
             newrelic_add_custom_tracer(\TYPO3\CMS\Core\Cache\Backend\WincacheBackend::class . '::set');
             newrelic_add_custom_tracer(\TYPO3\CMS\Core\Cache\Backend\WincacheBackend::class . '::flush');
             newrelic_add_custom_tracer(\TYPO3\CMS\Core\Cache\Backend\WincacheBackend::class . '::flushByTags');
         }
+    }
 
-        if (TYPO3_MODE === 'BE') {
+    if (isset($configuration['traceDataHandlerCommands']) && $configuration['traceDataHandlerCommands']) {
+        $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['processCmdmapClass'][]
+            = \NamelessCoder\NewrelicIntegration\Hooks\DataHandlerHookSubscriber::class;
+    }
 
-            if (isset($configuration['traceDataHandlerCommands']) && $configuration['traceDataHandlerCommands']) {
-                $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['processCmdmapClass'][] = \NamelessCoder\NewrelicIntegration\Hooks\DataHandlerHookSubscriber::class;
-            }
+    if (isset($configuration['traceTypoScriptParsing']) && $configuration['traceTypoScriptParsing']) {
+        newrelic_add_custom_tracer(\TYPO3\CMS\Core\TypoScript\Parser\TypoScriptParser::class . '::parse');
+        newrelic_add_custom_tracer(\TYPO3\CMS\Core\TypoScript\Parser\TypoScriptParser::class . '::includeFile');
+        newrelic_add_custom_tracer(\TYPO3\CMS\Core\TypoScript\Parser\TypoScriptParser::class . '::includeDirectory');
+    }
 
-            /*
-             * Since there is no constant for the 'web_layout' module name, use it directly.
-             * Up to TYPO3 v10, it was possible to use $pageLayoutController->MCONF['name']
-             */
-            $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['cms/layout/db_layout.php']['drawFooterHook']['newrelic_integration'] = function() {
-                newrelic_name_transaction('BE/web_layout');
-            };
+    if (version_compare(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::getExtensionVersion('core'), '12.0', '<')) {
+        /*
+         * Since there is no constant for the 'web_layout' module name, use it directly.
+         * Up to TYPO3 v10, it was possible to use $pageLayoutController->MCONF['name']
+         */
+        /** In TYPO3 v12.0, this hook has been replaced by a PSR-14 event */
+        $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['cms/layout/db_layout.php']['drawFooterHook']['newrelic_integration'] = static function() {
+            newrelic_name_transaction('BE/web_layout');
+        };
 
-        }
+        /** In TYPO3 v12.0, this hook has been replaced by a PSR-14 event */
+        if (isset($configuration['tracePageUid']) && $configuration['tracePageUid']) {
+            $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_fe.php']['determineId-PostProc']['newrelic'] = static function(
+                array $parameters,
+                \TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController $controller
+            ) use ($configuration, $applicationType) {
 
-        if (TYPO3_MODE === 'FE') {
-
-            if (isset($configuration['traceTypoScriptParsing']) && $configuration['traceTypoScriptParsing']) {
-                newrelic_add_custom_tracer(\TYPO3\CMS\Core\TypoScript\Parser\TypoScriptParser::class . '::parse');
-                newrelic_add_custom_tracer(\TYPO3\CMS\Core\TypoScript\Parser\TypoScriptParser::class . '::includeFile');
-                newrelic_add_custom_tracer(\TYPO3\CMS\Core\TypoScript\Parser\TypoScriptParser::class . '::includeDirectory');
-            }
-
-            if (isset($configuration['tracePageUid']) && $configuration['tracePageUid']) {
-                $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_fe.php']['determineId-PostProc']['newrelic'] = function(
-                    array $parameters,
-                    \TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController $controller
-                ) use ($configuration) {
-                    newrelic_name_transaction(TYPO3_MODE . '/page-' . $controller->id . '-default');
-                    if (isset($configuration['tracePageType']) && $configuration['tracePageType']) {
-                        if (\TYPO3\CMS\Core\Utility\GeneralUtility::_GP('type') ?? null) {
-                            newrelic_name_transaction(TYPO3_MODE . '/page-' . $controller->id . '-type' . \TYPO3\CMS\Core\Utility\GeneralUtility::_GP('type'));
-                        }
-                    }
-                };
-            }
-
-            if (isset($configuration['traceFrontendUsers']) && $configuration['traceFrontendUsers']) {
-                $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_fe.php']['initFEuser']['newrelic'] = function(
-                    array $parameters,
-                    \TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController $controller
-                ) use ($configuration) {
-                    $login = $controller->fe_user->getLoginFormData();
-                    if (!empty($login) && $login['status'] === 'login') {
-                        newrelic_name_transaction('FE login');
-                    }
-                    if (empty($controller->fe_user->user['uid'])) {
-                        newrelic_add_custom_parameter('Frontend user', 'Anonymous');
-                    } else {
-                        $traceFrontendUsersFields = !empty($configuration['traceFrontendUsersFields']) ? \TYPO3\CMS\Core\Utility\GeneralUtility::trimExplode(',', $configuration['traceFrontendUsersFields']) : ['uid', 'username', 'company', 'email'];
-                        $traceFields = [];
-                        foreach ($traceFrontendUsersFields as $traceFrontendUsersField) {
-                            $traceFields[] = $controller->fe_user->user[$traceFrontendUsersField];
-                        }
-
-                        newrelic_add_custom_parameter(
-                            'Frontend user',
-                            implode(
-                                ', ',
-                                $traceFields
+                newrelic_name_transaction($applicationType . '/page-' . $controller->id . '-default');
+                if (isset($configuration['tracePageType']) && $configuration['tracePageType']) {
+                    if (\TYPO3\CMS\Core\Utility\GeneralUtility::_GP('type') ?? null) {
+                        newrelic_name_transaction(
+                            $applicationType . '/page-' . $controller->id . '-type' . \TYPO3\CMS\Core\Utility\GeneralUtility::_GP(
+                                'type'
                             )
                         );
                     }
-                };
-            }
+                }
+            };
         }
     }
 
+    if (version_compare(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::getExtensionVersion('core'), '9.5', '<')) {
+        /** In TYPO3 v9.5, this hook has been deprecated and replaced by a PSR-15 middleware */
+        if (isset($configuration['traceFrontendUsers']) && $configuration['traceFrontendUsers']) {
+            $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_fe.php']['initFEuser']['newrelic'] = static function(
+                array $parameters,
+                \TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController $controller
+            ) use ($configuration) {
+                $login = $controller->fe_user->getLoginFormData($GLOBALS['TYPO3_REQUEST']);
+                if (!empty($login) && $login['status'] === 'login') {
+                    newrelic_name_transaction('FE login');
+                }
+                if (empty($controller->fe_user->user['uid'])) {
+                    newrelic_add_custom_parameter('Frontend user', 'Anonymous');
+                } else {
+                    $traceFrontendUsersFields = !empty($configuration['traceFrontendUsersFields']) ? \TYPO3\CMS\Core\Utility\GeneralUtility::trimExplode(',', $configuration['traceFrontendUsersFields']) : ['uid', 'username', 'company', 'email'];
+                    $traceFields = [];
+                    foreach ($traceFrontendUsersFields as $traceFrontendUsersField) {
+                        $traceFields[] = $controller->fe_user->user[$traceFrontendUsersField];
+                    }
+
+                    newrelic_add_custom_parameter(
+                        'Frontend user',
+                        implode(
+                            ', ',
+                            $traceFields
+                        )
+                    );
+                }
+            };
+        }
+    }
 })();


### PR DESCRIPTION
This pull requests adds TYPO3 v12 support to the New Relic integration extension.

## AfterPageAndLanguageIsResolvedEvent
The `AfterPageAndLanguageIsResolvedEvent` class implements the `AfterPageAndLanguageIsResolvedEvent` event as replacement of the `determineId-PostProc` hook. That hook is being used to trace specific page requests. Please see https://docs.typo3.org/m/typo3/reference-coreapi/12.4/en-us/ApiOverview/Events/Events/Frontend/AfterPageAndLanguageIsResolvedEvent.html

## ModifyPageLayoutContentEvent
The `PageLayoutContentEvent` implements the `ModifyPageLayoutContentEvent` event as replacement of the `drawFooterHook`. This is being used to trace backend webview requests. Please see https://docs.typo3.org/m/typo3/reference-coreapi/12.4/en-us/ApiOverview/Events/Events/Backend/ModifyPageLayoutContentEvent.html

## FrontendUserAuthenticator
The `FrontendUserAuthenticator` middleware as replacement for the in v10 removed hook `initFEuser`. This is being used to trace frontend user requests. Please see https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/9.5/Deprecation-86279-VariousHooksAndPSR-15Middlewares.html and https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/10.0/Breaking-87193-DeprecatedFunctionalityRemoved.html

## Other changes
The other changes in `ext_localconf.php` are version checks to load some code for specific versions only (to prevent duplicate execution of code or to prevent deprecation warnings)